### PR TITLE
BT-3585-out-of-memory-errors-toil

### DIFF
--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1427,7 +1427,7 @@ class JobDescription(Requirer):
                 BatchJobExitReason.OVERUSE,
                 BatchJobExitReason.CONTAINER_MEMLIMIT,
             )
-            or exit_status in (137, 143)
+            or exit_status in (137, 143, 9)
         ) and self._config.doubleMem:
             # 137 = 128 + 9 - occurs when a job is killed due to memory limit by kernel on oom-killer invoked
             # 143 occurs when a container based job is killed due to memory limit by kernel on oom-killer invoked


### PR DESCRIPTION
**Description**
JIRA Ticket: BT-3585
- Now handling exit status 9, which corresponds to exit code 137 (Out of Memory error from GATK).
- The Toil pipeline is configured to exit with a hardcoded exit code 9 in such cases.
- In addition to GATK, other functions that encounter similar failures are now also handled with exit code 9.